### PR TITLE
TRITON-2081 docker volume creation error mismatch

### DIFF
--- a/lib/endpoints/volumes.js
+++ b/lib/endpoints/volumes.js
@@ -587,24 +587,11 @@ function createVolume(req, res, next) {
                     payload: storageVmPayload
                 }, {
                     headers: {'x-request-id': req.getId()}
-                }, function onVmCreated(vmCreationErr, vmCreationObj) {
-                    var err;
-
-                    if (vmCreationErr) {
-                        req.log.error({error: vmCreationErr},
-                            'Error when creating storage VM');
-                    } else {
-                        req.log.debug({
-                            vmCreation: vmCreationObj,
-                            error: vmCreationErr
-                        }, 'Storage VM created');
-                    }
-
-                    cb(err);
-                });
+                }, cb);
             }
 
-            _createStorageVmWithVersion(NFS_VERSION_2, function _createCb(err) {
+            _createStorageVmWithVersion(NFS_VERSION_2,
+                    function _createCb(err, vmobj) {
                 if (err && err.message && err.message.indexOf(
                         NO_COMPUTE_RESOURCES_AVAILABLE) >= 0) {
                     // Fallback - try and create a version 1 nfs zone, which
@@ -614,16 +601,19 @@ function createVolume(req, res, next) {
                     return;
                 }
 
-                _done(err);
+                _done(err, vmobj);
             });
 
-            function _done(err) {
+            function _done(err, vmobj) {
                 if (err) {
+                    req.log.error({error: err},
+                        'Error when creating storage VM');
                     done(new errors.InternalError(err,
                         'Error when creating storage VM'));
                     return;
                 }
 
+                req.log.debug({vm: vmobj}, 'Storage VM successfully created');
                 done();
             }
         }


### PR DESCRIPTION
The docker test passes after this change:
```
# /zones/aec18af5-6c04-40cb-8287-df96505f5cfa/root/opt/smartdc/docker/test/runtests -f cli-nfs-shared-volumes-create-failure.test.js
...
# Volume creation should fail when provision fails
# creating volume test-nfs-shared-volume-b0bbcb98 should fail with appropriate error message
ok 9 volume creation should not succeed
ok 10 expected "problem creating volume" error message
...

# test results:
# Completed in 12 seconds.
# PASS: 11 / 11
```