### PR TITLE
TRITON-2085 volapi v1 fallback is not working

### DIFF
--- a/lib/endpoints/volumes.js
+++ b/lib/endpoints/volumes.js
@@ -597,7 +597,24 @@ function createVolume(req, res, next) {
                     // Fallback - try and create a version 1 nfs zone, which
                     // will use different platform requirements (not as strict
                     // as version 2).
-                    _createStorageVmWithVersion(NFS_VERSION_1, _done);
+                    req.log.info('No volapi v2 compute resources - ' +
+                        'falling back to volapi v1');
+
+                    // Have to set a new vm uuid, otherwise the provision will
+                    // fail with a duplicate uuid error message.
+                    var volume = context.volumeObject.value;
+                    ctx.storageVmUuid = volume.vm_uuid = libuuid.create();
+                    volumesModel.updateVolumeWithRetry(volume.uuid,
+                            context.volumeObject,
+                            function _onUpdateCb(updateErr) {
+                        if (updateErr) {
+                            _done(updateErr);
+                            return;
+                        }
+
+                        // Create the volapi v1 storage zone.
+                        _createStorageVmWithVersion(NFS_VERSION_1, _done);
+                    });
                     return;
                 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdc-volapi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SDC's Volumes API",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Fallback now working correctly:
```
$ triton volume create -w -s 10G -n todd-vol2
Creating volume todd-vol2 (a1473dd6-8178-64cf-b64a-9077108d3d16)
Created volume todd-vol2 (a1473dd6-8178-64cf-b64a-9077108d3d16)

# sdc-volapi /volumes/a1473dd6-8178-64cf-b64a-9077108d3d16 | json -H vm_uuid
e4d0210c-3d50-c5ea-c342-d0735d31e4d3

# vmadm get e4d0210c-3d50-c5ea-c342-d0735d31e4d3 | json internal_metadata
{
  "sdc:system_role": "nfsvolumestorage"
}
```