### PR TITLE
TRITON-2133 volapi GetReferences can crash when there are no references

### DIFF
--- a/lib/endpoints/volumes.js
+++ b/lib/endpoints/volumes.js
@@ -1043,7 +1043,7 @@ function getVolumeReferences(req, res, next) {
     assert.func(next, 'next');
 
     var volumeObject = req.loadedVolumeObject;
-    req.volumeReferences = volumeObject.value.refs;
+    req.volumeReferences = volumeObject.value.refs || [];
 
     next();
 }
@@ -1527,15 +1527,12 @@ function renderVolumes(req, res, next) {
 }
 
 function renderVolumeReferences(req, res, next) {
-    var volumeReferences;
-
     assert.object(req, 'req');
     assert.object(res, 'res');
     assert.func(next, 'next');
 
-    assert.object(req.volumeReferences, 'req.volumeReferences');
-    volumeReferences = req.volumeReferences;
-    req.renderedResponse = volumeReferences;
+    assert.arrayOfString(req.volumeReferences, 'req.volumeReferences');
+    req.renderedResponse = req.volumeReferences;
 
     next();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdc-volapi",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "SDC's Volumes API",
   "main": "server.js",
   "scripts": {

--- a/test/integration/nfs-shared-volumes.test.js
+++ b/test/integration/nfs-shared-volumes.test.js
@@ -366,6 +366,20 @@ test('nfs shared volumes', function (tt) {
             });
         });
 
+    tt.test('check volume references are empty', function (t) {
+        if (!sharedNfsVolume) {
+            t.end();
+            return;
+        }
+
+        var opts = { path: '/volumes/' + sharedNfsVolume.uuid + '/references'};
+        CLIENTS.volapi.get(opts, function onVolumeReferences(err, references) {
+            t.ifErr(err, 'getVolumeReferences should not error');
+            t.deepEqual(references, [], 'volume references should be empty');
+            t.end();
+        });
+    });
+
     tt.test('create a VM that references the volume', function (t) {
         if (!sharedNfsVolume) {
             t.end();


### PR DESCRIPTION
```
# test results:
# Completed in 471 seconds.
# PASS: 330 / 330
```